### PR TITLE
Fix overflowing 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ ADD restore.sh /restore.sh
 ADD run.sh /run.sh
 RUN chmod 755 /*.sh
 
+VOLUME /tmp/backups/
+
 CMD ["/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.9
 
 RUN apk add --no-cache bash py-pip gnupg \
   && pip install awscli

--- a/backup.sh
+++ b/backup.sh
@@ -2,6 +2,10 @@
 export PATH=$PATH:/usr/bin:/usr/local/bin:/bin
 # Get timestamp
 : ${BACKUP_SUFFIX:=.$(date +"%Y-%m-%d-%H-%M-%S")}
+
+# create backups in docker volume directory
+cd /tmp/backups/
+
 tarball=$BACKUP_NAME$BACKUP_SUFFIX.tar.gz
 
 # Create a gzip compressed tarball with the volume(s)

--- a/restore.sh
+++ b/restore.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# create backups in docker volume directory
+cd /tmp/backups/
+
 # Find last backup file
 : ${LAST_BACKUP:=$(aws s3 ls s3://$S3_BUCKET_NAME | awk -F " " '{print $4}' | grep ^$BACKUP_NAME | sort -r | head -n1)}
 

--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@ else
 fi
 
 if [ -n "$CRON_TIME" ]; then
-  echo "${CRON_TIME} /backup.sh >> /dockup.log 2>&1" > /var/spool/cron/crontabs/root
+  echo "${CRON_TIME} /backup.sh >> /tmp/backups/dockup.log 2>&1" > /var/spool/cron/crontabs/root
   echo "=> Running dockup backups as a cronjob for ${CRON_TIME}"
   exec crond -f
 fi


### PR DESCRIPTION
Apparently if you write to container root filesystem enough docker on amazon linux breaks at times, and results in a read only filesystem. We had this happen once, and the solution is to write most FS changes to a docker volume.

Ref:
https://github.com/moby/moby/issues/18010